### PR TITLE
Fix Writer failing with assertion error

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -3,11 +3,9 @@
  * Module dependencies.
  */
 
-var assert = require('assert');
 var inherits = require('util').inherits;
 var debug = require('debug')('wave:writer');
 var Transform = require('stream').Transform;
-var Parser = require('stream-parser');
 
 // for node v0.8.x support, remove after v0.12.x
 if (!Transform) Transform = require('readable-stream/transform');
@@ -73,6 +71,7 @@ function Writer (opts) {
   this.channels = 2;
   this.sampleRate = 44100;
   this.bitDepth = 16;
+  this.bytesProcessed = 0
 
   if (opts) {
     if (null != opts.format) this.format = opts.format;
@@ -81,17 +80,10 @@ function Writer (opts) {
     if (null != opts.bitDepth) this.bitDepth = opts.bitDepth;
   }
 
-  // the first time _transform() is called, _writeHeader() will be run
-  //this.immediate(this._writeHeader);
-  this._bytes(0, this._writeHeader);
+  this._writeHeader()
 }
 inherits(Writer, Transform);
 
-/**
- * Mixin `Parser`.
- */
-
-Parser(Writer.prototype);
 
 /**
  * Writes the WAVE header.
@@ -99,7 +91,7 @@ Parser(Writer.prototype);
  * @api private
  */
 
-Writer.prototype._writeHeader = function (chunk, write) {
+Writer.prototype._writeHeader = function () {
   debug('_writeHeader()');
   var headerLength = 44; // TODO: 44 is only for format 1 (PCM), any other
                          // format will have a variable size...
@@ -181,9 +173,7 @@ Writer.prototype._writeHeader = function (chunk, write) {
   this._header = header;
   this.headerLength = headerLength;
 
-  // flush the header and after that pass-through "dataLength" bytes
-  write(header);
-  this._passthrough(dataLength, this._onEnd);
+  this.push(header);
 };
 
 /**
@@ -197,12 +187,24 @@ Writer.prototype._onEnd = function (write) {
 };
 
 /**
+ * Transform incoming data. We don't do anything special, just pass it through.
+ *
+ * @api private
+ */
+
+Writer.prototype._transform = function (chunk, enc, done) {
+  this.push(chunk)
+  this.bytesProcessed += chunk.length
+  done()
+};
+
+/**
  * Emits a "header" event after the readable side of the stream has finished.
  *
  * @api private
  */
 
-Writer.prototype._flush = function (write, done) {
+Writer.prototype._flush = function (done) {
   debug('_flush()');
   done();
   this.dataLength = this.bytesProcessed;


### PR DESCRIPTION
```
AssertionError: can only buffer a finite number of bytes > 0, got "0"
writer.js:86:  this._bytes(0, this._writeHeader);
```

I'm guessing stream-parser has been updated since this code was written. The simplest way I could find to get the Writer working was bypassing stream-parser and implementing the through stream directly. 

Hopefully I haven't just missed something obvious here.
