### PR TITLE
Support 'JUNK' data block in RIFF specification.

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -102,10 +102,19 @@ Reader.prototype._onSubchunk1ID = function (chunk) {
   this.chunkId = subchunk1ID;
   if ('fmt ' === subchunk1ID) {
     this._bytes(4, this._onSubchunk1Size);
+  } else if ('JUNK' === subchunk1ID) {
+    this._bytes(4, this._onJUNK);
   } else {
     this.emit('error', new Error(f('bad "fmt id": expected "fmt ", got %j', subchunk1ID)));
   }
 };
+
+Reader.prototype._onJUNK = function (chunk) {
+  var junkSize = chunk['readUInt32' + this.endianness](0);
+  this._bytes(junkSize, function() {
+    this._bytes(4, this._onSubchunk1ID);
+  });
+}
 
 Reader.prototype._onSubchunk1Size = function (chunk) {
   debug('onSubchunk1Size: %o', chunk);


### PR DESCRIPTION
Some audio authoring tools still produce .wav files with 'JUNK' sections (a relic from CD-ROM days).