### PR TITLE
Add semistandard linting

### DIFF
--- a/examples/wavinfo.js
+++ b/examples/wavinfo.js
@@ -28,23 +28,23 @@ input.pipe(reader);
 // a few final properties will have been parsed like "subchunk2Size" that we want
 // to print out to simulate the wavinfo(1) command
 reader.once('readable', function () {
-  console.log('WaveHeader Size:\t%d',  12);
+  console.log('WaveHeader Size:\t%d', 12);
   console.log('ChunkHeader Size:\t%d', 8);
   console.log('FormatChunk Size:\t%d', reader.subchunk1Size);
-  console.log('RIFF ID:\t%s',          reader.riffId);
-  console.log('Total Size:\t%d',       reader.chunkSize);
-  console.log('Wave ID:\t%s',          reader.waveId);
-  console.log('Chunk ID:\t%s',         reader.chunkId);
-  console.log('Chunk Size:\t%d',       reader.subchunk1Size);
+  console.log('RIFF ID:\t%s', reader.riffId);
+  console.log('Total Size:\t%d', reader.chunkSize);
+  console.log('Wave ID:\t%s', reader.waveId);
+  console.log('Chunk ID:\t%s', reader.chunkId);
+  console.log('Chunk Size:\t%d', reader.subchunk1Size);
   console.log('Compression format is of type: %d', reader.audioFormat);
-  console.log('Channels:\t%d',         reader.channels);
-  console.log('Sample Rate:\t%d',      reader.sampleRate);
-  console.log('Bytes / Sec:\t%d',      reader.byteRate);
-  console.log('wBlockAlign:\t%d',      reader.blockAlign);
+  console.log('Channels:\t%d', reader.channels);
+  console.log('Sample Rate:\t%d', reader.sampleRate);
+  console.log('Bytes / Sec:\t%d', reader.byteRate);
+  console.log('wBlockAlign:\t%d', reader.blockAlign);
   console.log('Bits Per Sample Point:\t%d', reader.bitDepth);
   // TODO: this should end up being "44" or whatever the total length of the WAV
   //       header is. maybe emit "format" at this point rather than earlier???
-  console.log('wavDataPtr: %d',       0);
-  console.log('wavDataSize: %d',      reader.subchunk2Size);
+  console.log('wavDataPtr: %d', 0);
+  console.log('wavDataSize: %d', reader.subchunk2Size);
   console.log();
 });

--- a/lib/file-writer.js
+++ b/lib/file-writer.js
@@ -59,4 +59,6 @@ FileWriter.prototype._onHeader = function (header) {
     if (err) return self.emit('error', err);
     self.emit('done');
   }
+
+  fs.open(self.path, 'r+', onOpen);
 };

--- a/lib/file-writer.js
+++ b/lib/file-writer.js
@@ -39,7 +39,8 @@ inherits(FileWriter, Writer);
  */
 
 FileWriter.prototype._onHeader = function (header) {
-  var self = this, fd;
+  var self = this;
+  var fd;
 
   function onOpen (err, f) {
     if (err) return self.emit('error', err);
@@ -49,7 +50,7 @@ FileWriter.prototype._onHeader = function (header) {
 
   function onWrite (err, bytesWritten) {
     if (err) return self.emit('error', err);
-    if (bytesWritten != header.length) {
+    if (bytesWritten !== header.length) {
       return self.emit('error', new Error('problem writing "header" data'));
     }
     fs.close(fd, onClose);

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -4,7 +4,6 @@
  */
 
 var util = require('util');
-var assert = require('assert');
 var Parser = require('stream-parser');
 var Transform = require('readable-stream/transform');
 var debug = require('debug')('wave:reader');
@@ -16,14 +15,14 @@ var f = util.format;
  */
 
 var formats = {
-  WAVE_FORMAT_UNKNOWN:    0x0000, // Microsoft Unknown Wave Format
-  WAVE_FORMAT_PCM:        0x0001, // Microsoft PCM Format
-  WAVE_FORMAT_ADPCM:      0x0002, // Microsoft ADPCM Format
+  WAVE_FORMAT_UNKNOWN: 0x0000, // Microsoft Unknown Wave Format
+  WAVE_FORMAT_PCM: 0x0001, // Microsoft PCM Format
+  WAVE_FORMAT_ADPCM: 0x0002, // Microsoft ADPCM Format
   WAVE_FORMAT_IEEE_FLOAT: 0x0003, // IEEE float
-  WAVE_FORMAT_VSELP:      0x0004, // Compaq Computer's VSELP
-  WAVE_FORMAT_IBM_CVSD:   0x0005, // IBM CVSD
-  WAVE_FORMAT_ALAW:       0x0006, // 8-bit ITU-T G.711 A-law
-  WAVE_FORMAT_MULAW:      0x0007, // 8-bit ITU-T G.711 µ-law
+  WAVE_FORMAT_VSELP: 0x0004, // Compaq Computer's VSELP
+  WAVE_FORMAT_IBM_CVSD: 0x0005, // IBM CVSD
+  WAVE_FORMAT_ALAW: 0x0006, // 8-bit ITU-T G.711 A-law
+  WAVE_FORMAT_MULAW: 0x0007, // 8-bit ITU-T G.711 µ-law
   WAVE_FORMAT_EXTENSIBLE: 0xFFFE  // Determined by SubFormat
 };
 
@@ -64,11 +63,11 @@ Parser(Reader.prototype);
 Reader.prototype._onRiffID = function (chunk) {
   debug('onRiffID: %o', chunk);
   var id = this.riffId = chunk.toString('ascii');
-  if ('RIFF' === id) {
+  if (id === 'RIFF') {
     debug('detected little-endian WAVE file');
     this.endianness = 'LE';
     this._bytes(4, this._onChunkSize);
-  } else if ('RIFX' === id) {
+  } else if (id === 'RIFX') {
     debug('detected big-endian WAVE file');
     this.endianness = 'BE';
     this._bytes(4, this._onChunkSize);
@@ -88,7 +87,7 @@ Reader.prototype._onChunkSize = function (chunk) {
 Reader.prototype._onFormat = function (chunk) {
   debug('onFormat: %o', chunk);
   this.waveId = chunk.toString('ascii');
-  if ('WAVE' === this.waveId) {
+  if (this.waveId === 'WAVE') {
     this._bytes(4, this._onSubchunk1ID);
   } else {
     this.emit('error', new Error(f('bad "format": expected "WAVE", got %j', this.waveId)));
@@ -100,7 +99,7 @@ Reader.prototype._onSubchunk1ID = function (chunk) {
   debug('onSubchunk1ID: %o', chunk);
   var subchunk1ID = chunk.toString('ascii');
   this.chunkId = subchunk1ID;
-  if ('fmt ' === subchunk1ID) {
+  if (subchunk1ID === 'fmt ') {
     this._bytes(4, this._onSubchunk1Size);
   } else {
     this.emit('error', new Error(f('bad "fmt id": expected "fmt ", got %j', subchunk1ID)));
@@ -122,7 +121,7 @@ Reader.prototype._onSubchunk1 = function (chunk) {
   this.byteRate = chunk['readUInt32' + this.endianness](8); // useless...
   this.blockAlign = chunk['readUInt16' + this.endianness](12); // useless...
   this.bitDepth = chunk['readUInt16' + this.endianness](14);
-  this.signed = this.bitDepth != 8;
+  this.signed = this.bitDepth !== 8;
 
   var format = {
     audioFormat: this.audioFormat,
@@ -159,10 +158,10 @@ Reader.prototype._onSubchunk2ID = function (chunk) {
   debug('onSubchunk2ID: %o', chunk);
   var subchunk2ID = chunk.toString('ascii');
 
-  if ('data' === subchunk2ID) {
+  if (subchunk2ID === 'data') {
     // Data Chunk - "data"
     this._bytes(4, this._onDataChunkSize);
-  } else if ('fact' === subchunk2ID) {
+  } else if (subchunk2ID === 'fact') {
     // Fact Chunk - "fact"
     this._bytes(4, this._onFactChunkSize);
   } else {
@@ -178,7 +177,7 @@ Reader.prototype._onDataChunkSize = function (chunk) {
   debug('onDataChunkSize: %o', chunk);
   var chunkSize = chunk['readUInt32' + this.endianness](0);
 
-  if (0 === chunkSize) {
+  if (chunkSize === 0) {
     // Some encoders write `0` for the byte length here in the case of a WAV file
     // being generated on-the-fly. In that case, we're just gonna passthrough the
     // remaining bytes assuming they're going to be audio data.

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -21,7 +21,7 @@ module.exports = Writer;
 
 var RIFF = new Buffer('RIFF');
 var WAVE = new Buffer('WAVE');
-var fmt  = new Buffer('fmt ');
+var fmt = new Buffer('fmt ');
 var data = new Buffer('data');
 
 /**
@@ -68,19 +68,18 @@ function Writer (opts) {
   this.channels = 2;
   this.sampleRate = 44100;
   this.bitDepth = 16;
-  this.bytesProcessed = 0
+  this.bytesProcessed = 0;
 
   if (opts) {
-    if (null != opts.format) this.format = opts.format;
-    if (null != opts.channels) this.channels = opts.channels;
-    if (null != opts.sampleRate) this.sampleRate = opts.sampleRate;
-    if (null != opts.bitDepth) this.bitDepth = opts.bitDepth;
+    if (opts.format != null) this.format = opts.format;
+    if (opts.channels != null) this.channels = opts.channels;
+    if (opts.sampleRate != null) this.sampleRate = opts.sampleRate;
+    if (opts.bitDepth != null) this.bitDepth = opts.bitDepth;
   }
 
-  this._writeHeader()
+  this._writeHeader();
 }
 inherits(Writer, Transform);
-
 
 /**
  * Writes the WAVE header.
@@ -93,7 +92,7 @@ Writer.prototype._writeHeader = function () {
   var headerLength = 44; // TODO: 44 is only for format 1 (PCM), any other
                          // format will have a variable size...
   var dataLength = this.dataLength;
-  if (null == dataLength) {
+  if (dataLength == null) {
     debug('using default "dataLength" of %d', MAX_WAV);
     dataLength = MAX_WAV;
   }
@@ -137,7 +136,7 @@ Writer.prototype._writeHeader = function () {
 
   // write the byte rate
   var byteRate = this.byteRate;
-  if (null == byteRate) {
+  if (byteRate == null) {
     byteRate = this.sampleRate * this.channels * this.bitDepth / 8;
   }
   header['writeUInt32' + this.endianness](byteRate, offset);
@@ -145,7 +144,7 @@ Writer.prototype._writeHeader = function () {
 
   // write the block align
   var blockAlign = this.blockAlign;
-  if (null == blockAlign) {
+  if (blockAlign == null) {
     blockAlign = this.channels * this.bitDepth / 8;
   }
   header['writeUInt16' + this.endianness](blockAlign, offset);
@@ -190,9 +189,9 @@ Writer.prototype._onEnd = function (write) {
  */
 
 Writer.prototype._transform = function (chunk, enc, done) {
-  this.push(chunk)
-  this.bytesProcessed += chunk.length
-  done()
+  this.push(chunk);
+  this.bytesProcessed += chunk.length;
+  done();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
     "stream-parser": "~0.3.0"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "*",
+    "semistandard": "^8.0.0"
   },
   "main": "./index.js",
   "scripts": {
-    "test": "mocha --reporter spec"
+    "test": "semistandard && mocha --reporter spec"
   }
 }

--- a/test/reader.js
+++ b/test/reader.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 
 /**
  * Module dependencies.
@@ -9,9 +10,7 @@ var assert = require('assert');
 var Reader = require('../').Reader;
 
 describe('Reader', function () {
-
   describe('RIFF - Little-endian', function () {
-
     describe('1up.wav', function () {
       var fixture = path.resolve(__dirname, 'fixtures', '1up.wav');
 
@@ -33,7 +32,6 @@ describe('Reader', function () {
         reader.on('end', done);
         fs.createReadStream(fixture).pipe(reader).resume();
       });
-
     });
 
     describe('gameover.wav', function () {
@@ -62,7 +60,6 @@ describe('Reader', function () {
         reader.on('end', done);
         fs.createReadStream(fixture).pipe(reader).resume();
       });
-
     });
 
     describe('M1F1-float32-AFsp.wav', function () {
@@ -87,7 +84,6 @@ describe('Reader', function () {
         reader.on('end', done);
         fs.createReadStream(fixture).pipe(reader).resume();
       });
-
     });
 
     describe('M1F1-float64-AFsp.wav', function () {
@@ -112,14 +108,10 @@ describe('Reader', function () {
         reader.on('end', done);
         fs.createReadStream(fixture).pipe(reader).resume();
       });
-
     });
-
-
   });
 
   describe('RIFX - Big-endian', function () {
-
     describe('gameover-rifx.wav', function () {
       var fixture = path.resolve(__dirname, 'fixtures', 'gameover-rifx.wav');
 
@@ -146,9 +138,6 @@ describe('Reader', function () {
         reader.on('end', done);
         fs.createReadStream(fixture).pipe(reader).resume();
       });
-
     });
-
   });
-
 });


### PR DESCRIPTION
I would personally prefer [standard](https://github.com/feross/standard) but since we already had semicolons I wanted to keep the diff as short as possible to not introduce conflicts with the other open PRs. My long term goal is to switch to standard, but lets take that later...